### PR TITLE
Syntax fix for example definition of existing Model instance

### DIFF
--- a/docs/api/javascript/data/datasource.md
+++ b/docs/api/javascript/data/datasource.md
@@ -1069,7 +1069,7 @@ If set to an existing [`kendo.data.Model`](/api/javascript/data/model) instance,
 #### Example - set the model as an existing `kendo.data.Model` instance
 
     <script>
-    var Product = kendo.model.define({
+    var Product = kendo.data.Model.define({
       id: "ProductID",
       fields: {
         ProductID: {


### PR DESCRIPTION
There's a small but functionally important error with the syntax of sample code for "Example - set the model as an existing kendo.data.Model instance" 